### PR TITLE
SCMOD-7788: Use oss version of elasticsearch

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # Reference the official Elasticsearch 7 image
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.2.0 AS es7-image
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.2.0 AS es7-image
 
 #
 # The actual image definition


### PR DESCRIPTION
JIRA: https://portal.digitalsafe.net/browse/SCMOD-7788
Dev builds of worker-classification that are using this base image dev build:
- http://sou-jenkins2.hpeswlab.net/job/Verity/view/Developer/job/Verity~worker-classification~SCMOD-7788~CI/
- http://sou-jenkins2.hpeswlab.net/job/Verity/view/Developer/job/Verity~worker-classification~SCMOD-7788/