### PR TITLE
SCMOD-9841: Upgrade to Elasticsearch version 7.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,10 +159,8 @@
                                 <ports>
                                     <port>${es.http.port}:9200</port>
                                     <port>${es.client.port}:9300</port>
-                                    <port>${es.debug.port}:9010</port>
                                 </ports>
                                 <env>
-                                    <ES_JAVA_OPTS>-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false</ES_JAVA_OPTS>
                                     <discovery.type>single-node</discovery.type>
                                 </env>
                                 <log>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,20 @@
                         </goals>
                     </execution>
                     <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <id>docker-push</id>
                         <phase>deploy</phase>
                         <goals>
@@ -141,6 +155,27 @@
                                     </inline>
                                 </assembly>
                             </build>
+                            <run>
+                                <ports>
+                                    <port>${es.http.port}:9200</port>
+                                    <port>${es.client.port}:9300</port>
+                                    <port>${es.debug.port}:9010</port>
+                                </ports>
+                                <env>
+                                    <ES_JAVA_OPTS>-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false</ES_JAVA_OPTS>
+                                    <discovery.type>single-node</discovery.type>
+                                </env>
+                                <log>
+                                    <enabled>true</enabled>
+                                </log>
+                                <wait>
+                                    <http>
+                                        <url>http://${docker.host.address}:${es.http.port}</url>
+                                    </http>
+                                    <time>300000</time>
+                                    <shutdown>500</shutdown>
+                                </wait>
+                            </run>
                         </image>
                     </images>
                     <verbose>true</verbose>

--- a/release-notes-3.0.0.md
+++ b/release-notes-3.0.0.md
@@ -4,7 +4,7 @@
 ${version-number}
 
 #### New Features
-- None
+- **SCMOD-9841**: Updated to Elasticsearch version [7.7.0](https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-7.7.0.html)
 
 #### Known Issues
 - None
@@ -12,4 +12,3 @@ ${version-number}
 #### Breaking Changes
 - **SCMOD-8516**: Extend the security hardening of Java base images by disabling TLS algorithms mentioned [here](https://github.com/CAFapi/opensuse-java8-images/blob/develop/src/main/docker/disableWeakTlsAlgorithms.patch)
 - **SCMOD-9780**: Updated to Java 11
-- **SCMOD-9841**: Updated to Elasticsearch 7.7.0

--- a/release-notes-3.0.0.md
+++ b/release-notes-3.0.0.md
@@ -12,3 +12,4 @@ ${version-number}
 #### Breaking Changes
 - **SCMOD-8516**: Extend the security hardening of Java base images by disabling TLS algorithms mentioned [here](https://github.com/CAFapi/opensuse-java8-images/blob/develop/src/main/docker/disableWeakTlsAlgorithms.patch)
 - **SCMOD-9780**: Updated to Java 11
+- **SCMOD-9841**: Updated to Elasticsearch 7.7.0

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -65,6 +65,7 @@ RUN chmod +x /opt/elasticsearch/scripts/*
 
 # Startup Elasticsearch and expose ports
 EXPOSE 9200 9300
+USER elasticsearch
 CMD /opt/elasticsearch/scripts/start.sh
 
 # Tag the image

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # Reference the official Elasticsearch 7 image
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.3.2 AS es7-image
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.7.0 AS es7-image
 
 #
 # The actual image definition

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -65,7 +65,6 @@ RUN chmod +x /opt/elasticsearch/scripts/*
 
 # Startup Elasticsearch and expose ports
 EXPOSE 9200 9300
-USER elasticsearch
 CMD /opt/elasticsearch/scripts/start.sh
 
 # Tag the image


### PR DESCRIPTION
Jira: https://portal.digitalsafe.net/browse/SCMOD-9841